### PR TITLE
Update go mux API image tag to panchanandevops/golang-mux-app:2.0.1

### DIFF
--- a/Deploy/go-helm-chart/values.yaml
+++ b/Deploy/go-helm-chart/values.yaml
@@ -13,7 +13,7 @@ deployment:
   container:
     name: golang-mux-app
     port: 8000
-    image: panchanandevops/golang-mux-app:v1.0.0
+    image: panchanandevops/golang-mux-app:2.0.1
     resources:
       limits:
         memory: "512Mi"

--- a/Deploy/k8s/5-api-deployment.yaml
+++ b/Deploy/k8s/5-api-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: go-api
-          image: panchanandevops/golang-mux-app:v1.0.0
+          image: panchanandevops/golang-mux-app:2.0.1
           ports:
             - containerPort: 8000
           resources:

--- a/Deploy/kustomize/base/5-api-deployment.yaml
+++ b/Deploy/kustomize/base/5-api-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: go-api
-          image: panchanandevops/golang-mux-app:v1.0.0
+          image: panchanandevops/golang-mux-app:2.0.1
           ports:
             - containerPort: 8000
           resources:

--- a/trivy-results.sarif
+++ b/trivy-results.sarif
@@ -1,0 +1,34 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "fullName": "Trivy Vulnerability Scanner",
+          "informationUri": "https://github.com/aquasecurity/trivy",
+          "name": "Trivy",
+          "rules": [],
+          "version": "0.53.0"
+        }
+      },
+      "results": [],
+      "columnKind": "utf16CodeUnits",
+      "originalUriBaseIds": {
+        "ROOTPATH": {
+          "uri": "file:///"
+        }
+      },
+      "properties": {
+        "imageID": "sha256:71f575daeb0675f60e5371d82bba343f01e846eedd1af9394482e103e5b1475c",
+        "imageName": "panchanandevops/golang-mux-app:2.0.1",
+        "repoDigests": [
+          "panchanandevops/golang-mux-app@sha256:c46252fdb413f455beb46b7fad96555e89c3d698071ab36741ad3d92db059c4b"
+        ],
+        "repoTags": [
+          "panchanandevops/golang-mux-app:2.0.1"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR updates the go mux API image tag to panchanandevops/golang-mux-app:2.0.1.